### PR TITLE
New Sniff: Forbidden classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ with some noticeable exceptions/differences/extensions based on best-practices a
 - Use Null Coalesce Operator ``$foo = $bar ?? $baz``
 - Prefer early exit over nesting conditions or using else
 - Always use fully-qualified global functions (without needing `use function` statements)
+- Forbids the use of `\DateTime`
 
 For full reference of enforcements, go through ``src/Unleashed/ruleset.xml`` where each sniff is briefly described.
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0.x-dev"
+            "dev-master": "3.0.x-dev"
         }
     },
     "support" : {

--- a/src/Unleashed/Sniffs/PHP/ForbiddenClassesSniff.php
+++ b/src/Unleashed/Sniffs/PHP/ForbiddenClassesSniff.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Unleashed\Sniffs\PHP;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use SlevomatCodingStandard\Helpers\NamespaceHelper;
+use SlevomatCodingStandard\Helpers\ReferencedNameHelper;
+use SlevomatCodingStandard\Helpers\TokenHelper;
+
+final class ForbiddenClassesSniff implements Sniff
+{
+    public const FORBIDDEN = 'Forbidden';
+
+    /**
+     * A list of fully-qualified class, interface, or trait names
+     *
+     * @var string[]
+     */
+    public $forbiddenClasses = [
+        // phpcs:disable Unleashed.PHP.ForbiddenClasses.Forbidden
+        \DateTime::class,
+        // phpcs:enable
+    ];
+
+    /**
+     * If true, an error will be thrown; otherwise a warning
+     *
+     * @var bool
+     */
+    public $error = true;
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @inheritDoc
+     */
+    public function register(): array
+    {
+        return [\T_OPEN_TAG];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if (TokenHelper::findPrevious($phpcsFile, T_OPEN_TAG, $stackPtr - 1) !== null) {
+            return;
+        }
+
+        $referencedNames = ReferencedNameHelper::getAllReferencedNames($phpcsFile, $stackPtr);
+
+        foreach ($referencedNames as $referencedName) {
+            $pointer = $referencedName->getStartPointer();
+            $name    = $referencedName->getNameAsReferencedInFile();
+
+            $fullyQualifiedName = NamespaceHelper::resolveClassName($phpcsFile, $name, $pointer);
+
+            if (! \in_array($fullyQualifiedName, $this->forbiddenClasses, true)) {
+                continue;
+            }
+
+            $error = \sprintf('The use of "%s" is forbidden', $fullyQualifiedName);
+            if ($this->error) {
+                $phpcsFile->addError($error, $pointer, self::FORBIDDEN);
+            } else {
+                $phpcsFile->addWarning($error, $pointer, self::FORBIDDEN);
+            }
+        }
+    }
+}

--- a/src/Unleashed/ruleset.xml
+++ b/src/Unleashed/ruleset.xml
@@ -106,6 +106,13 @@
             </property>
         </properties>
     </rule>
+    <rule ref="Unleashed.PHP.ForbiddenClasses">
+        <properties>
+            <property name="forbiddenClasses" type="array">
+                <element value="\DateTime"/>
+            </property>
+        </properties>
+    </rule>
     <!-- Forbid useless inline string concatenation -->
     <rule ref="Generic.Strings.UnnecessaryStringConcat">
         <!-- But multiline is useful for readability -->

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -18,6 +18,7 @@ tests/input/EarlyReturn.php                           6       0
 tests/input/example-class.php                         38      0
 tests/input/forbidden-comments.php                    14      0
 tests/input/forbidden-functions.php                   13      0
+tests/input/ForbiddenClasses.php                      7       0
 tests/input/fully-qualified-and-fallbacks.php         1       0
 tests/input/fully-qualified-without-namespace.php     3       0
 tests/input/inline_type_hint_assertions.php           7       0
@@ -47,7 +48,7 @@ tests/input/use-ordering.php                          9       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     23      0
 ----------------------------------------------------------------------
-A TOTAL OF 411 ERRORS AND 8 WARNINGS WERE FOUND IN 43 FILES
+A TOTAL OF 418 ERRORS AND 8 WARNINGS WERE FOUND IN 44 FILES
 ----------------------------------------------------------------------
 PHPCBF CAN FIX 334 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------

--- a/tests/fixed/ForbiddenClasses.php
+++ b/tests/fixed/ForbiddenClasses.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test;
+
+use DateTime as Date;
+
+class ForbiddenClasses extends Date implements Date
+{
+    use Date;
+
+    public function foo(): void
+    {
+        $x = new Date();
+        $y = new \DateTime();
+
+        if ($x instanceof Date) {
+            echo Date::ISO8601;
+        }
+    }
+}

--- a/tests/fixed/duplicate-assignment-variable.php
+++ b/tests/fixed/duplicate-assignment-variable.php
@@ -4,4 +4,4 @@ declare(strict_types=1);
 
 $foo = $bar = new stdClass();
 
-$baz = $baz = new DateTime();
+$baz = $baz = new DateTimeImmutable();

--- a/tests/input/ForbiddenClasses.php
+++ b/tests/input/ForbiddenClasses.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test;
+
+use DateTime as Date;
+
+class ForbiddenClasses extends Date implements Date
+{
+    use Date;
+
+    public function foo(): void
+    {
+        $x = new Date();
+        $y = new \DateTime();
+
+        if ($x instanceof Date) {
+            echo Date::ISO8601;
+        }
+    }
+}

--- a/tests/input/duplicate-assignment-variable.php
+++ b/tests/input/duplicate-assignment-variable.php
@@ -4,4 +4,4 @@ declare(strict_types=1);
 
 $foo = $bar = new stdClass();
 
-$baz = $baz = new DateTime();
+$baz = $baz = new DateTimeImmutable();

--- a/tests/php-compatibility.patch
+++ b/tests/php-compatibility.patch
@@ -42,8 +42,33 @@ index 71be9a5..f9492c7 100644
          // @see https://github.com/php/php-src/blob/PHP-7.4/Zend/zend_compile.c "zend_try_compile_special_func"
          'array_key_exists'     => true,
          'array_slice'          => true,
+diff --git a/src/Unleashed/Sniffs/PHP/ForbiddenClassesSniff.php b/src/Unleashed/Sniffs/PHP/ForbiddenClassesSniff.php
+index 80a42a6..dd2fcb7 100644
+--- a/src/Unleashed/Sniffs/PHP/ForbiddenClassesSniff.php
++++ b/src/Unleashed/Sniffs/PHP/ForbiddenClassesSniff.php
+@@ -19,7 +19,7 @@ final class ForbiddenClassesSniff implements Sniff
+      *
+      * @var string[]
+      */
+-    public $forbiddenClasses = [
++    public array $forbiddenClasses = [
+         // phpcs:disable Unleashed.PHP.ForbiddenClasses.Forbidden
+         \DateTime::class,
+         // phpcs:enable
+@@ -27,10 +27,8 @@ final class ForbiddenClassesSniff implements Sniff
+ 
+     /**
+      * If true, an error will be thrown; otherwise a warning
+-     *
+-     * @var bool
+      */
+-    public $error = true;
++    public bool $error = true;
+ 
+     /**
+      * Returns an array of tokens this test wants to listen for.
 diff --git a/tests/expected_report.txt b/tests/expected_report.txt
-index c07423b..9b0ebf0 100644
+index cc0cd5a..c3ebeb0 100644
 --- a/tests/expected_report.txt
 +++ b/tests/expected_report.txt
 @@ -11,11 +11,11 @@ tests/input/concatenation_spacing.php                 49      0
@@ -59,8 +84,8 @@ index c07423b..9b0ebf0 100644
 +tests/input/example-class.php                         41      0
  tests/input/forbidden-comments.php                    14      0
  tests/input/forbidden-functions.php                   13      0
- tests/input/fully-qualified-and-fallbacks.php         1       0
-@@ -40,16 +40,16 @@ tests/input/strict-functions.php                      4       0
+ tests/input/ForbiddenClasses.php                      7       0
+@@ -41,16 +41,16 @@ tests/input/strict-functions.php                      4       0
  tests/input/test-case.php                             7       0
  tests/input/trailing_comma_on_array.php               1       0
  tests/input/traits-uses.php                           12      0
@@ -72,8 +97,8 @@ index c07423b..9b0ebf0 100644
  tests/input/useless-semicolon.php                     2       0
  tests/input/UselessConditions.php                     23      0
  ----------------------------------------------------------------------
--A TOTAL OF 411 ERRORS AND 8 WARNINGS WERE FOUND IN 43 FILES
-+A TOTAL OF 416 ERRORS AND 8 WARNINGS WERE FOUND IN 43 FILES
+-A TOTAL OF 418 ERRORS AND 8 WARNINGS WERE FOUND IN 44 FILES
++A TOTAL OF 423 ERRORS AND 8 WARNINGS WERE FOUND IN 44 FILES
  ----------------------------------------------------------------------
 -PHPCBF CAN FIX 334 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 +PHPCBF CAN FIX 339 OF THESE SNIFF VIOLATIONS AUTOMATICALLY


### PR DESCRIPTION
By default, only `\DateTime` is forbidden.  Other classes/interfaces/traits can be blocklisted via configuration.