### PR TITLE
Feature/updating standards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,6 @@ test-fix: vendor
 vendor: composer.json
 	composer update
 	touch -c vendor
+
+update-tests-to-latest-standards: vendor
+	./bin/update-tests-to-latest-standards

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ with some noticeable exceptions/differences/extensions based on best-practices a
 - Don't use ``@author``, ``@since`` and similar annotations that duplicate Git information
 - Use parentheses when creating new instances that do not require arguments ``$foo = new Foo()``
 - Use Null Coalesce Operator ``$foo = $bar ?? $baz``
+- Use Null Safe Object Operator ``$foo = $object?->property``
 - Prefer early exit over nesting conditions or using else
 - Always use fully-qualified global functions (without needing `use function` statements)
 - Forbids the use of `\DateTime`

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ This coding standard is based on [PSR-1](https://github.com/php-fig/fig-standard
 with some noticeable exceptions/differences/extensions based on best-practices adopted by Symfony, Doctrine, and the wider community:
 
 - Keep the nesting of control structures per method as small as possible
-- Align equals (``=``) signs in assignments
 - Add spaces around a concatenation operator ``$foo = 'Hello ' . 'World!';``
 - Add spaces between assignment, control and return statements
 - Add spaces after the colon in return type declaration ``function (): void {}``

--- a/bin/update-tests-to-latest-standards
+++ b/bin/update-tests-to-latest-standards
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set +e
+
+cp -R tests/input/ tests/updated/
+vendor/bin/phpcbf tests/updated
+
+rm -rf tests/fixed
+mv tests/updated tests/fixed
+
+# shellcheck disable=SC2046
+vendor/bin/phpcs $(find tests/input/* | sort) --report=summary --report-file=updated-report.txt
+mv updated-report.txt tests/expected_report.txt

--- a/src/Unleashed/Sniffs/Commenting/ForbiddenSingleLineCommentsSniff.php
+++ b/src/Unleashed/Sniffs/Commenting/ForbiddenSingleLineCommentsSniff.php
@@ -48,7 +48,7 @@ final class ForbiddenSingleLineCommentsSniff implements Sniff
             $fix = $phpcsFile->addFixableError(
                 \sprintf('Code contains forbidden comment "%s".', \trim($content)),
                 $stackPtr,
-                self::CODE_COMMENT_FORBIDDEN
+                self::CODE_COMMENT_FORBIDDEN,
             );
 
             if (! $fix) {

--- a/src/Unleashed/Sniffs/Commenting/InheritDocFormatSniff.php
+++ b/src/Unleashed/Sniffs/Commenting/InheritDocFormatSniff.php
@@ -54,7 +54,7 @@ final class InheritDocFormatSniff implements Sniff
             $fix = $phpcsFile->addFixableError(
                 \sprintf('Incorrect formatting of "%s"', $this->style),
                 $i,
-                self::CODE_INVALID_INHERITDOC_STYLE
+                self::CODE_INVALID_INHERITDOC_STYLE,
             );
 
             if (! $fix) {

--- a/src/Unleashed/Sniffs/DoctrineMigrations/DescriptionRequiredSniff.php
+++ b/src/Unleashed/Sniffs/DoctrineMigrations/DescriptionRequiredSniff.php
@@ -52,14 +52,14 @@ final class DescriptionRequiredSniff implements Sniff
             $fix = $phpcsFile->addFixableError(
                 'Doctrine Migrations must have a getDescription() method.',
                 TokenHelper::findPrevious($phpcsFile, T_CLASS, $stackPtr),
-                self::CODE_MISSING_DESCRIPTION
+                self::CODE_MISSING_DESCRIPTION,
             );
 
             if ($fix) {
                 $phpcsFile->fixer->beginChangeset();
                 $phpcsFile->fixer->addContent(
                     TokenHelper::findNext($phpcsFile, T_OPEN_CURLY_BRACKET, $stackPtr),
-                    "\n    public function getDescription(): string\n    {\n        return '';\n    }"
+                    "\n    public function getDescription(): string\n    {\n        return '';\n    }",
                 );
                 $phpcsFile->fixer->endChangeset();
             }
@@ -76,7 +76,7 @@ final class DescriptionRequiredSniff implements Sniff
         $phpcsFile->addError(
             'Doctrine Migrationss must return useful information from getDescription(); empty strings not allowed',
             $returnValuePtr,
-            self::CODE_EMPTY_DESCRIPTION
+            self::CODE_EMPTY_DESCRIPTION,
         );
     }
 

--- a/src/Unleashed/ruleset.xml
+++ b/src/Unleashed/ruleset.xml
@@ -224,12 +224,16 @@
                 <!-- Symfony validation -->
                 <element value="@Assert\"/>
                 <!-- Types -->
-                <element value="@param"/>
-                <element value="@psalm-param"/>
-                <element value="@phpstan-param"/>
-                <element value="@return"/>
-                <element value="@psalm-return"/>
-                <element value="@phpstan-return"/>
+                <element value="
+                    @param,
+                    @psalm-param,
+                    @phpstan-param,
+                "/>
+                <element value="
+                    @return,
+                    @psalm-return,
+                    @phpstan-return,
+                "/>
                 <element value="@throws"/>
                 <element value="
                     @property,

--- a/src/Unleashed/ruleset.xml
+++ b/src/Unleashed/ruleset.xml
@@ -132,6 +132,8 @@
     <rule ref="SlevomatCodingStandard.Arrays.SingleLineArrayWhitespace"/>
     <!-- Require comma after last element in multi-line array -->
     <rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma"/>
+    <!-- Require no space before : and 1 space before Enum type -->
+    <rule ref="SlevomatCodingStandard.Classes.BackedEnumTypeSpacing"/>
     <!-- Require presence of constant visibility -->
     <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility">
         <properties>

--- a/src/Unleashed/ruleset.xml
+++ b/src/Unleashed/ruleset.xml
@@ -365,16 +365,38 @@
     <rule ref="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly"/>
     <!-- Require non-capturing catch when the variable with exception is not used -->
     <rule ref="SlevomatCodingStandard.Exceptions.RequireNonCapturingCatch"/>
+    <!-- Check the formatting of "fn" arrow functions -->
+    <rule ref="SlevomatCodingStandard.Functions.ArrowFunctionDeclaration"/>
+    <!-- Disallow trailing commas in single line function calls -->
+    <rule ref="SlevomatCodingStandard.Functions.DisallowTrailingCommaInCall">
+        <properties>
+            <property name="onlySingleLine" value="true" />
+        </properties>
+    </rule>
+    <!-- Disallow trailing commas in single line closure use -->
+    <rule ref="SlevomatCodingStandard.Functions.DisallowTrailingCommaInClosureUse">
+        <properties>
+            <property name="onlySingleLine" value="true" />
+        </properties>
+    </rule>
+    <!-- Disallow trailing commas in single line function declarations -->
+    <rule ref="SlevomatCodingStandard.Functions.DisallowTrailingCommaInDeclaration">
+        <properties>
+            <property name="onlySingleLine" value="true" />
+        </properties>
+    </rule>
+    <!-- Require trailing commas in multiline function calls -->
+    <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInCall"/>
+    <!-- Require trailing commas in multiline closure use -->
+    <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInClosureUse"/>
+    <!-- Require trailing commas in multiline function declarations -->
+    <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration"/>
     <!-- Require closures not referencing $this be static -->
     <rule ref="SlevomatCodingStandard.Functions.StaticClosure"/>
     <!-- Require calls to PHP functions that have a `$strict` parameter to always set that to `true` -->
     <rule ref="SlevomatCodingStandard.Functions.StrictCall"/>
-    <!-- Require trailing commas in multi-line declarations -->
-    <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration"/>
     <!-- Forbid unused variables passed to closures via `use` -->
     <rule ref="SlevomatCodingStandard.Functions.UnusedInheritedVariablePassedToClosure"/>
-    <!-- Check the formatting of "fn" arrow functions -->
-    <rule ref="SlevomatCodingStandard.Functions.ArrowFunctionDeclaration"/>
     <!-- Require use statements to be alphabetically sorted -->
     <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses">
         <properties>

--- a/src/Unleashed/ruleset.xml
+++ b/src/Unleashed/ruleset.xml
@@ -317,7 +317,7 @@
     <rule ref="SlevomatCodingStandard.Commenting.DeprecatedAnnotationDeclaration"/>
     <!-- Report invalid format of inline phpDocs with @var -->
     <rule ref="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration"/>
-    <!-- Require comments with single line written as one-liners -->
+    <!-- Requires property comments with single-line content to be written as one-liners -->
     <rule ref="SlevomatCodingStandard.Commenting.RequireOneLinePropertyDocComment"/>
     <!-- Require consistent spacing for block structures -->
     <rule ref="SlevomatCodingStandard.ControlStructures.BlockControlStructureSpacing">

--- a/src/Unleashed/ruleset.xml
+++ b/src/Unleashed/ruleset.xml
@@ -497,7 +497,12 @@
     <!-- Forbid useless semicolon `;` -->
     <rule ref="SlevomatCodingStandard.PHP.UselessSemicolon"/>
     <!-- Require /* @var type $foo */ and similar simple inline annotations to be replaced by assert() -->
-    <rule ref="SlevomatCodingStandard.PHP.RequireExplicitAssertion"/>
+    <rule ref="SlevomatCodingStandard.PHP.RequireExplicitAssertion">
+        <properties>
+            <property name="enableAdvancedStringTypes" value="true"/>
+            <property name="enableIntegerRanges" value="true"/>
+        </properties>
+    </rule>
     <!-- Require use of short versions of scalar types (i.e. int instead of integer) -->
     <rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints"/>
     <!-- Require the `null` type hint to be in the last position of annotations -->

--- a/src/Unleashed/ruleset.xml
+++ b/src/Unleashed/ruleset.xml
@@ -58,6 +58,8 @@
     </rule>
     <!-- Force whitespace after `!` -->
     <rule ref="Generic.Formatting.SpaceAfterNot"/>
+    <!-- Prevent passing variables by reference when calling a function -->
+    <rule ref="Generic.Functions.CallTimePassByReference"/>
     <!-- Forbid PHP 4 constructors -->
     <rule ref="Generic.NamingConventions.ConstructorName"/>
     <!-- Forbid any content before opening tag -->
@@ -70,6 +72,7 @@
             <property name="forbiddenFunctions" type="array">
                 <element key="chop" value="rtrim"/>
                 <element key="close" value="closedir"/>
+                <element key="compact" value="null"/>
                 <element key="delete" value="unset"/>
                 <element key="doubleval" value="floatval"/>
                 <element key="extract" value="null"/>
@@ -116,6 +119,8 @@
     </rule>
     <!-- Forbid backtick operator -->
     <rule ref="Generic.PHP.BacktickOperator"/>
+    <!-- Require that true, false, and null are lowercase -->
+    <rule ref="Generic.PHP.LowerCaseConstant"/>
     <!-- Force PHP 7 param and return types to be lowercased -->
     <rule ref="Generic.PHP.LowerCaseType"/>
     <!-- Forbid `php_sapi_name()` function -->
@@ -156,8 +161,6 @@
     </rule>
     <!-- Forbid LSB for constants (static::FOO) -->
     <rule ref="SlevomatCodingStandard.Classes.DisallowLateStaticBindingForConstants"/>
-    <!-- Require that true, false, and null are lowercase -->
-    <rule ref="Generic.PHP.LowerCaseConstant"/>
     <!-- Forbid empty lines around type declarations -->
     <rule ref="SlevomatCodingStandard.Classes.EmptyLinesAroundClassBraces">
         <properties>
@@ -538,11 +541,12 @@
             </property>
         </properties>
     </rule>
+    <!-- Define unions style -->
     <rule ref="SlevomatCodingStandard.TypeHints.UnionTypeHintFormat">
         <properties>
-            <property name="withSpaces" value="no"/>
-            <property name="shortNullable" value="no"/>
-            <property name="nullPosition" value="last"/>
+            <property name="withSpaces" value="no" />
+            <property name="shortNullable" value="no" />
+            <property name="nullPosition" value="last" />
         </properties>
     </rule>
     <!-- Forbid useless @var for constants -->
@@ -700,15 +704,12 @@
     <!-- Forbid superfluous whitespaces -->
     <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
         <properties>
-            <!-- turned on by PSR2 -> turning back off -->
+            <!-- turned on by PSR-12 -> turning back off -->
             <property name="ignoreBlankLines" value="false"/>
         </properties>
     </rule>
     <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines">
-        <!-- turned off by PSR2 -> turning back on -->
+        <!-- turned off by PSR-12 -> turning back on -->
         <severity>5</severity>
     </rule>
-
-    <!-- Prevent passing variables by reference when calling a function -->
-    <rule ref="Generic.Functions.CallTimePassByReference"/>
 </ruleset>

--- a/src/Unleashed/ruleset.xml
+++ b/src/Unleashed/ruleset.xml
@@ -128,6 +128,14 @@
     </rule>
     <!-- Forbid conditional if() statements -->
     <rule ref="Generic.CodeAnalysis.UnconditionalIfStatement"/>
+    <!-- Disallow multiple attributes inside one #[] -->
+    <rule ref="SlevomatCodingStandard.Attributes.DisallowAttributesJoining"/>
+    <!-- Require only one attribute per line -->
+    <rule ref="SlevomatCodingStandard.Attributes.DisallowMultipleAttributesPerLine"/>
+    <!-- Attributes should be adjoined to the PHP element they belong to -->
+    <rule ref="SlevomatCodingStandard.Attributes.AttributeAndTargetSpacing"/>
+    <!-- Require PHPDoc always before attributes -->
+    <rule ref="SlevomatCodingStandard.Attributes.RequireAttributeAfterDocComment"/>
     <!-- Require that single line arrays have the correct spacing: no space around brackets and one space after comma -->
     <rule ref="SlevomatCodingStandard.Arrays.SingleLineArrayWhitespace"/>
     <!-- Require comma after last element in multi-line array -->

--- a/src/Unleashed/ruleset.xml
+++ b/src/Unleashed/ruleset.xml
@@ -160,7 +160,12 @@
     <!-- Require usage of ::class instead of __CLASS__, get_class(), get_class($this), get_called_class() and get_parent_class() -->
     <rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference"/>
     <!-- https://github.com/slevomat/coding-standard#slevomatcodingstandardclassespropertydeclaration- -->
-    <rule ref="SlevomatCodingStandard.Classes.PropertyDeclaration"/>
+    <rule ref="SlevomatCodingStandard.Classes.PropertyDeclaration">
+        <properties>
+            <property name="checkPromoted" value="true"/>
+            <property name="enableMultipleSpacesBetweenModifiersCheck" value="true"/>
+        </properties>
+    </rule>
     <!-- Forbid uses of multiple traits separated by comma -->
     <rule ref="SlevomatCodingStandard.Classes.TraitUseDeclaration"/>
     <!-- Require no spaces before trait use, between trait uses and one space after trait uses -->

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -21,13 +21,13 @@ tests/input/Exceptions.php                            1       0
 tests/input/forbidden-comments.php                    14      0
 tests/input/forbidden-functions.php                   13      0
 tests/input/ForbiddenClasses.php                      7       0
-tests/input/fully-qualified-and-fallbacks.php         1       0
-tests/input/fully-qualified-without-namespace.php     3       0
+tests/input/fully-qualified-and-fallbacks.php         2       0
+tests/input/fully-qualified-without-namespace.php     4       0
 tests/input/inheritdoc.php                            12      1
 tests/input/inline_type_hint_assertions.php           7       0
 tests/input/LowCaseTypes.php                          3       0
 tests/input/merge-conflict.php                        6       0
-tests/input/namespaces-spacing.php                    12      0
+tests/input/namespaces-spacing.php                    13      0
 tests/input/NamingCamelCase.php                       10      0
 tests/input/negation-operator.php                     2       0
 tests/input/new_with_parentheses.php                  27      0
@@ -45,6 +45,7 @@ tests/input/static-closures.php                       1       0
 tests/input/strict-functions.php                      4       0
 tests/input/test-case.php                             7       0
 tests/input/trailing_comma_on_array.php               1       0
+tests/input/TrailingCommaOnFunctions.php              6       0
 tests/input/traits-uses.php                           12      0
 tests/input/type-hints.php                            6       0
 tests/input/UnusedVariables.php                       2       0
@@ -53,9 +54,9 @@ tests/input/use-ordering.php                          9       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     24      0
 ----------------------------------------------------------------------
-A TOTAL OF 493 ERRORS AND 9 WARNINGS WERE FOUND IN 49 FILES
+A TOTAL OF 502 ERRORS AND 9 WARNINGS WERE FOUND IN 50 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 402 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 411 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -16,6 +16,7 @@ tests/input/doctrine-migration.php                    18      6
 tests/input/duplicate-assignment-variable.php         1       0
 tests/input/EarlyReturn.php                           7       0
 tests/input/example-class.php                         46      0
+tests/input/ExampleBackedEnum.php                     4       0
 tests/input/forbidden-comments.php                    14      0
 tests/input/forbidden-functions.php                   13      0
 tests/input/ForbiddenClasses.php                      7       0
@@ -50,9 +51,9 @@ tests/input/use-ordering.php                          9       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     24      0
 ----------------------------------------------------------------------
-A TOTAL OF 478 ERRORS AND 9 WARNINGS WERE FOUND IN 46 FILES
+A TOTAL OF 482 ERRORS AND 9 WARNINGS WERE FOUND IN 47 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 387 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 391 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -35,7 +35,7 @@ tests/input/not_spacing.php                           12      0
 tests/input/null_coalesce_operator.php                3       0
 tests/input/null_safe_operator.php                    1       0
 tests/input/optimized-functions.php                   1       0
-tests/input/PropertyDeclaration.php                   9       0
+tests/input/PropertyDeclaration.php                   19      0
 tests/input/return_type_on_closures.php               26      0
 tests/input/return_type_on_methods.php                22      0
 tests/input/semicolon_spacing.php                     4       0
@@ -53,9 +53,9 @@ tests/input/use-ordering.php                          9       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     24      0
 ----------------------------------------------------------------------
-A TOTAL OF 483 ERRORS AND 9 WARNINGS WERE FOUND IN 49 FILES
+A TOTAL OF 493 ERRORS AND 9 WARNINGS WERE FOUND IN 49 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 392 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 402 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -20,7 +20,7 @@ tests/input/example-class.php                         46      0
 tests/input/ExampleBackedEnum.php                     4       0
 tests/input/Exceptions.php                            1       0
 tests/input/forbidden-comments.php                    14      0
-tests/input/forbidden-functions.php                   13      0
+tests/input/forbidden-functions.php                   14      0
 tests/input/ForbiddenClasses.php                      7       0
 tests/input/fully-qualified-and-fallbacks.php         2       0
 tests/input/fully-qualified-without-namespace.php     4       0
@@ -55,7 +55,7 @@ tests/input/use-ordering.php                          9       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     24      0
 ----------------------------------------------------------------------
-A TOTAL OF 517 ERRORS AND 9 WARNINGS WERE FOUND IN 51 FILES
+A TOTAL OF 518 ERRORS AND 9 WARNINGS WERE FOUND IN 51 FILES
 ----------------------------------------------------------------------
 PHPCBF CAN FIX 415 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -5,6 +5,7 @@ FILE                                                  ERRORS  WARNINGS
 ----------------------------------------------------------------------
 tests/input/array_indentation.php                     10      0
 tests/input/assignment-operators.php                  4       0
+tests/input/attributes.php                            15      0
 tests/input/binary_operators.php                      9       0
 tests/input/class-references.php                      10      0
 tests/input/concatenation_spacing.php                 54      0
@@ -54,9 +55,9 @@ tests/input/use-ordering.php                          9       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     24      0
 ----------------------------------------------------------------------
-A TOTAL OF 502 ERRORS AND 9 WARNINGS WERE FOUND IN 50 FILES
+A TOTAL OF 517 ERRORS AND 9 WARNINGS WERE FOUND IN 51 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 411 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 415 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -32,6 +32,7 @@ tests/input/negation-operator.php                     2       0
 tests/input/new_with_parentheses.php                  27      0
 tests/input/not_spacing.php                           12      0
 tests/input/null_coalesce_operator.php                3       0
+tests/input/null_safe_operator.php                    1       0
 tests/input/optimized-functions.php                   1       0
 tests/input/PropertyDeclaration.php                   9       0
 tests/input/return_type_on_closures.php               26      0
@@ -51,9 +52,9 @@ tests/input/use-ordering.php                          9       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     24      0
 ----------------------------------------------------------------------
-A TOTAL OF 482 ERRORS AND 9 WARNINGS WERE FOUND IN 47 FILES
+A TOTAL OF 483 ERRORS AND 9 WARNINGS WERE FOUND IN 48 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 391 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 392 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -25,7 +25,7 @@ tests/input/ForbiddenClasses.php                      7       0
 tests/input/fully-qualified-and-fallbacks.php         2       0
 tests/input/fully-qualified-without-namespace.php     4       0
 tests/input/inheritdoc.php                            12      1
-tests/input/inline_type_hint_assertions.php           7       0
+tests/input/inline_type_hint_assertions.php           10      0
 tests/input/LowCaseTypes.php                          3       0
 tests/input/merge-conflict.php                        6       0
 tests/input/namespaces-spacing.php                    13      0
@@ -55,9 +55,9 @@ tests/input/use-ordering.php                          9       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     24      0
 ----------------------------------------------------------------------
-A TOTAL OF 518 ERRORS AND 9 WARNINGS WERE FOUND IN 51 FILES
+A TOTAL OF 521 ERRORS AND 9 WARNINGS WERE FOUND IN 51 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 415 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 418 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -10,13 +10,14 @@ tests/input/class-references.php                      10      0
 tests/input/concatenation_spacing.php                 54      0
 tests/input/constants-no-lsb.php                      2       0
 tests/input/constants-var.php                         3       0
-tests/input/ControlStructures.php                     18      2
+tests/input/ControlStructures.php                     17      2
 tests/input/doc-comment-spacing.php                   17      0
 tests/input/doctrine-migration.php                    18      6
 tests/input/duplicate-assignment-variable.php         1       0
 tests/input/EarlyReturn.php                           7       0
 tests/input/example-class.php                         46      0
 tests/input/ExampleBackedEnum.php                     4       0
+tests/input/Exceptions.php                            1       0
 tests/input/forbidden-comments.php                    14      0
 tests/input/forbidden-functions.php                   13      0
 tests/input/ForbiddenClasses.php                      7       0
@@ -52,7 +53,7 @@ tests/input/use-ordering.php                          9       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     24      0
 ----------------------------------------------------------------------
-A TOTAL OF 483 ERRORS AND 9 WARNINGS WERE FOUND IN 48 FILES
+A TOTAL OF 483 ERRORS AND 9 WARNINGS WERE FOUND IN 49 FILES
 ----------------------------------------------------------------------
 PHPCBF CAN FIX 392 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------

--- a/tests/fixed/ExampleBackedEnum.php
+++ b/tests/fixed/ExampleBackedEnum.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ExampleBackedEnum;
+
+enum ExampleBackedEnum: int
+{
+}

--- a/tests/fixed/Exceptions.php
+++ b/tests/fixed/Exceptions.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Exceptions;
+
+use Exception;
+use Throwable;
+
+try {
+    throw new Exception();
+} catch (Throwable) {
+}

--- a/tests/fixed/PropertyDeclaration.php
+++ b/tests/fixed/PropertyDeclaration.php
@@ -10,4 +10,9 @@ final class PropertyDeclaration
     public string $stringProperty;
     public int $intProperty;
     public string|null $nullableString = null;
+
+    public function __construct(
+        public readonly Foo $foo,
+    ) {
+    }
 }

--- a/tests/fixed/TrailingCommaOnFunctions.php
+++ b/tests/fixed/TrailingCommaOnFunctions.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine;
+
+// phpcs:disable PSR1.Files.SideEffects
+
+class TrailingCommaOnFunctions
+{
+    public function a(int $arg): void
+    {
+    }
+
+    public function b(
+        int $arg,
+    ): void {
+    }
+
+    public function uses(): void
+    {
+        $var = null;
+
+        $singleLine = static function (int $arg) use ($var): void {
+            echo $var;
+        };
+
+        $multiLine = static function (int $arg) use (
+            $var,
+        ): void {
+            echo $var;
+        };
+    }
+}
+
+$class = new TrailingCommaOnFunctions();
+
+// phpcs:ignore Generic.Functions.FunctionCallArgumentSpacing.NoSpaceAfterComma
+$class->a(1);
+
+$class->a(
+    1,
+);

--- a/tests/fixed/attributes.php
+++ b/tests/fixed/attributes.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+#[Attribute1]
+#[Attribute2]
+#[Attribute3]
+class TestClass
+{
+}
+
+#[Attribute1]
+#[Attribute2]
+#[Attribute3]
+class TestClass2
+{
+}
+
+#[Attribute1]
+#[Attribute2]
+#[Attribute3]
+class TestClass3
+{
+}
+
+/** @internal */
+#[Attribute1]
+#[Attribute2]
+#[Attribute3]
+class TestClass4
+{
+}

--- a/tests/fixed/doc-comment-spacing.php
+++ b/tests/fixed/doc-comment-spacing.php
@@ -76,15 +76,11 @@ class Test
      *
      * @param int[] $foo
      * @param int[] $bar
-     *
      * @psalm-param list<int>
-     *
      * @phpstan-param int[]
      *
      * @return int[]
-     *
      * @psalm-return list<int>
-     *
      * @phpstan-return int[]
      *
      * @throws FooException

--- a/tests/fixed/fully-qualified-and-fallbacks.php
+++ b/tests/fixed/fully-qualified-and-fallbacks.php
@@ -13,5 +13,5 @@ use const DATE_RFC3339;
 \strrev(\strrev(
     (new \DateTimeImmutable('@' . now(), new DateTimeZone('UTC')))
         ->sub(new DateInterval('P1D'))
-        ->format(DATE_RFC3339)
+        ->format(DATE_RFC3339),
 ));

--- a/tests/fixed/fully-qualified-without-namespace.php
+++ b/tests/fixed/fully-qualified-without-namespace.php
@@ -7,5 +7,5 @@ use function time as now;
 strrev(strrev(
     (new DateTimeImmutable('@' . now(), new DateTimeZone('UTC')))
         ->sub(new DateInterval('P1D'))
-        ->format(DATE_RFC3339)
+        ->format(DATE_RFC3339),
 ));

--- a/tests/fixed/inline_type_hint_assertions.php
+++ b/tests/fixed/inline_type_hint_assertions.php
@@ -24,3 +24,12 @@ $multipleScalarTypes = expression();
 assert(is_int($multipleScalarTypes) || is_float($multipleScalarTypes) || is_bool($multipleScalarTypes) || is_string($multipleScalarTypes) || is_array($multipleScalarTypes) || $multipleScalarTypes === null);
 
 /** @var Potato $variableThatIsNowhereToBeFound */
+
+$a = 1;
+assert(is_int($a) && $a > 0);
+
+$aa = null;
+assert((is_int($aa) && $aa > 0) || $aa === null);
+
+$aaa = 'string';
+assert(is_string($aaa) && $aaa !== '');

--- a/tests/fixed/namespaces-spacing.php
+++ b/tests/fixed/namespaces-spacing.php
@@ -15,5 +15,5 @@ use const DATE_RFC3339;
 \strrev(
     (new DateTimeImmutable('@' . now(), new DateTimeZone('UTC')))
         ->sub(new DateInterval('P1D'))
-        ->format(DATE_RFC3339)
+        ->format(DATE_RFC3339),
 );

--- a/tests/fixed/null_safe_operator.php
+++ b/tests/fixed/null_safe_operator.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+$var = $object?->property;

--- a/tests/input/ControlStructures.php
+++ b/tests/input/ControlStructures.php
@@ -99,7 +99,7 @@ class ControlStructures
         }
         try {
             echo 4;
-        } catch (Throwable $throwable) {
+        } catch (Throwable) {
         }
         echo 5;
     }

--- a/tests/input/ExampleBackedEnum.php
+++ b/tests/input/ExampleBackedEnum.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ExampleBackedEnum;
+
+enum ExampleBackedEnum :   int
+{
+}

--- a/tests/input/Exceptions.php
+++ b/tests/input/Exceptions.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Exceptions;
+
+use Exception;
+use Throwable;
+
+try {
+    throw new Exception();
+} catch (Throwable $throwable) {
+}

--- a/tests/input/PropertyDeclaration.php
+++ b/tests/input/PropertyDeclaration.php
@@ -10,4 +10,9 @@ final class PropertyDeclaration
     public string  $stringProperty;
     public  int $intProperty;
     public ? string $nullableString = null;
+
+    public function __construct(
+        public  readonly  Foo  $foo,
+    ) {
+    }
 }

--- a/tests/input/TrailingCommaOnFunctions.php
+++ b/tests/input/TrailingCommaOnFunctions.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine;
+
+// phpcs:disable PSR1.Files.SideEffects
+
+class TrailingCommaOnFunctions
+{
+    public function a(int $arg,): void
+    {
+    }
+
+    public function b(
+        int $arg
+    ): void {
+    }
+
+    public function uses(): void
+    {
+        $var = null;
+
+        $singleLine = static function (int $arg) use ($var,): void {
+            echo $var;
+        };
+
+        $multiLine = static function (int $arg) use (
+            $var
+        ): void {
+            echo $var;
+        };
+    }
+}
+
+$class = new TrailingCommaOnFunctions();
+
+// phpcs:ignore Generic.Functions.FunctionCallArgumentSpacing.NoSpaceAfterComma
+$class->a(1,);
+
+$class->a(
+    1
+);

--- a/tests/input/attributes.php
+++ b/tests/input/attributes.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+#[Attribute1] #[Attribute2]
+#[Attribute3]
+class TestClass
+{
+}
+
+#[Attribute1,Attribute2]
+#[Attribute3]
+class TestClass2
+{
+}
+
+#[Attribute1]
+#[Attribute2]
+#[Attribute3]
+
+class TestClass3
+{
+}
+
+#[Attribute1]
+#[Attribute2]
+#[Attribute3]
+/** @internal */
+class TestClass4
+{
+}

--- a/tests/input/inline_type_hint_assertions.php
+++ b/tests/input/inline_type_hint_assertions.php
@@ -24,3 +24,12 @@ $nullableType = expression();
 $multipleScalarTypes = expression();
 
 /** @var Potato $variableThatIsNowhereToBeFound */
+
+/** @var positive-int $a */
+$a = 1;
+
+/** @var positive-int|null $aa */
+$aa = null;
+
+/** @var non-empty-string $aaa */
+$aaa = 'string';

--- a/tests/input/null_safe_operator.php
+++ b/tests/input/null_safe_operator.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+$var = $object === null ? null : $object->property;


### PR DESCRIPTION
Update General standards + better php 8 support

Here are the changes in this MR
### Updated
- Standard: Group php,psalm,phpstan param and return annotations (SlevomatCodingStandard.Commenting.DocCommentSpacing)
- Standard: Enforce property spacing for promoted properties (SlevomatCodingStandard.Classes.PropertyDeclaration)
- Standard: Add `compact` to ForbiddenFunctions (Generic.PHP.ForbiddenFunctions)
- Standard: Enforce explicit assertions for advanced string types and int ranges (SlevomatCodingStandard.PHP.RequireExplicitAssertion)
- Makefile: Add shell command to more easily update tests

### Added
- SlevomatCodingStandard.Classes.BackedEnumTypeSpacing
- SlevomatCodingStandard.Functions.RequireTrailingCommaInCall
- SlevomatCodingStandard.Functions.DisallowTrailingCommaInCall (for single line calls)
- SlevomatCodingStandard.Functions.RequireTrailingCommaInClosureUse
- SlevomatCodingStandard.Functions.DisallowTrailingCommaInClosureUse (for single line calls)
- SlevomatCodingStandard.Functions.DisallowTrailingCommaInDeclaration (for single line calls)
- SlevomatCodingStandard.Attributes.DisallowAttributesJoining
- SlevomatCodingStandard.Attributes.DisallowMultipleAttributesPerLine
- SlevomatCodingStandard.Attributes.AttributeAndTargetSpacing
- SlevomatCodingStandard.Attributes.RequireAttributeAfterDocComment