### PR TITLE
Require at least slevomat/coding-standard 8.6.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "require": {
         "php": "^8.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-        "slevomat/coding-standard": "^8",
+        "slevomat/coding-standard": "^8.6.4",
         "squizlabs/php_codesniffer": "^3.7"
     },
     "require-dev": {


### PR DESCRIPTION
At least 8.6.4 is needed to reference `SlevomatCodingStandard.Attributes.DisallowAttributesJoining`